### PR TITLE
Codex/add support for persistentdeviceid in signature pad

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -16,7 +16,7 @@ import { throttle } from './throttle';
 
 // PointerEvent with optional persistentDeviceId support
 export interface PersistentPointerEvent extends PointerEvent {
-  readonly persistentDeviceId?: any;
+  readonly persistentDeviceId?: unknown;
 }
 
 export { BasicPoint } from './point';
@@ -85,7 +85,7 @@ export default class SignaturePad extends SignatureEventTarget {
   private _lastVelocity = 0;
   private _lastWidth = 0;
   private _strokeMoveUpdate: (event: SignatureEvent) => void;
-  private _strokeDeviceId: any;
+  private _strokeDeviceId: unknown;
   /* tslint:enable: variable-name */
 
   constructor(
@@ -290,7 +290,7 @@ export default class SignaturePad extends SignatureEventTarget {
     return (event.buttons & 1) === 1;
   }
 
-  private _getEventDeviceId(event: PointerEvent): any {
+  private _getEventDeviceId(event: PointerEvent): unknown {
     const persistentId = (event as PersistentPointerEvent).persistentDeviceId;
     return persistentId ?? event.pointerId;
   }

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -14,6 +14,11 @@ import { BasicPoint, Point } from './point';
 import { SignatureEventTarget } from './signature_event_target';
 import { throttle } from './throttle';
 
+// PointerEvent with optional persistentDeviceId support
+export interface PersistentPointerEvent extends PointerEvent {
+  readonly persistentDeviceId?: any;
+}
+
 export { BasicPoint } from './point';
 
 export interface SignatureEvent {
@@ -80,7 +85,7 @@ export default class SignaturePad extends SignatureEventTarget {
   private _lastVelocity = 0;
   private _lastWidth = 0;
   private _strokeMoveUpdate: (event: SignatureEvent) => void;
-  private _strokePointerId : number | undefined;
+  private _strokeDeviceId: any;
   /* tslint:enable: variable-name */
 
   constructor(
@@ -284,6 +289,12 @@ export default class SignaturePad extends SignatureEventTarget {
 
     return (event.buttons & 1) === 1;
   }
+
+  private _getEventDeviceId(event: PointerEvent): any {
+    const persistentId = (event as PersistentPointerEvent).persistentDeviceId;
+    return persistentId ?? event.pointerId;
+  }
+
   private _pointerEventToSignatureEvent(
     event: MouseEvent | PointerEvent,
   ): SignatureEvent {
@@ -383,7 +394,7 @@ export default class SignaturePad extends SignatureEventTarget {
       return;
     }
 
-    this._strokePointerId = event.pointerId;
+    this._strokeDeviceId = this._getEventDeviceId(event);
     
     event.preventDefault();
 
@@ -400,7 +411,7 @@ export default class SignaturePad extends SignatureEventTarget {
       return;
     }
 
-    if (event.pointerId != this._strokePointerId) {
+    if (this._getEventDeviceId(event) != this._strokeDeviceId) {
       return;
     }
 
@@ -413,7 +424,11 @@ export default class SignaturePad extends SignatureEventTarget {
       return;
     }
 
-    this._strokePointerId = undefined;
+    if (this._getEventDeviceId(event) !== this._strokeDeviceId) {
+      return;
+    }
+
+    this._strokeDeviceId = undefined;
 
     event.preventDefault();
     this._strokeEnd(this._pointerEventToSignatureEvent(event));

--- a/tests/utils/pointer-event-polyfill.ts
+++ b/tests/utils/pointer-event-polyfill.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /*
  * Jest does not support `PointerEvent` yet. Please see this GitHub issue
  * for context: https://github.com/jsdom/jsdom/pull/2666
@@ -19,12 +18,12 @@ if (!global.PointerEvent) {
     public tiltY?: number;
     public twist?: number;
     public width?: number;
-    public persistentDeviceId?: any;
+    public persistentDeviceId?: unknown;
 
-    constructor(type: string, params: PointerEventInit & { persistentDeviceId?: any } = {}) {
+    constructor(type: string, params: PointerEventInit & { persistentDeviceId?: unknown } = {}) {
       super(type, params);
       this.pointerId = params.pointerId;
-      this.persistentDeviceId = (params as any).persistentDeviceId;
+      this.persistentDeviceId = (params as { persistentDeviceId?: unknown }).persistentDeviceId;
       this.width = params.width;
       this.height = params.height;
       this.pressure = params.pressure;
@@ -35,5 +34,5 @@ if (!global.PointerEvent) {
       this.isPrimary = params.isPrimary;
     }
   }
-  global.PointerEvent = PointerEvent as any;
+  global.PointerEvent = PointerEvent as unknown as typeof globalThis.PointerEvent;
 }

--- a/tests/utils/pointer-event-polyfill.ts
+++ b/tests/utils/pointer-event-polyfill.ts
@@ -19,10 +19,12 @@ if (!global.PointerEvent) {
     public tiltY?: number;
     public twist?: number;
     public width?: number;
+    public persistentDeviceId?: any;
 
-    constructor(type: string, params: PointerEventInit = {}) {
+    constructor(type: string, params: PointerEventInit & { persistentDeviceId?: any } = {}) {
       super(type, params);
       this.pointerId = params.pointerId;
+      this.persistentDeviceId = (params as any).persistentDeviceId;
       this.width = params.width;
       this.height = params.height;
       this.pressure = params.pressure;

--- a/tests/utils/pointer-event-polyfill.ts
+++ b/tests/utils/pointer-event-polyfill.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /*
  * Jest does not support `PointerEvent` yet. Please see this GitHub issue
  * for context: https://github.com/jsdom/jsdom/pull/2666
@@ -34,5 +35,5 @@ if (!global.PointerEvent) {
       this.isPrimary = params.isPrimary;
     }
   }
-  global.PointerEvent = PointerEvent as unknown as typeof globalThis.PointerEvent;
+  global.PointerEvent = PointerEvent as any;
 }


### PR DESCRIPTION
# Summary

- extend PointerEvent typings for the experimental persistentDeviceId
- track pointer device using persistentDeviceId when available
- update pointer event polyfill for tests
